### PR TITLE
Feat: Add Barewire Agentic Proxy for Enhanced AI Observability & Control

### DIFF
--- a/src/lib/aiClient.ts
+++ b/src/lib/aiClient.ts
@@ -108,10 +108,22 @@ const perplexity = new OpenAI({
   baseURL: "https://api.perplexity.ai",
 });
 
+// Barewire client for agentic proxy, observability, and compliance
+// Routes all OpenAI-compatible calls through Barewire if configured.
+const barewire = new OpenAI({
+  apiKey: process.env.BAREWIRE_API_KEY,
+  baseURL: process.env.BAREWIRE_BASE_URL || "https://api.barewire.com/v1",
+});
+
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
 
 function getClientForModel(model: AIModel): AIClientResponse {
   const modelId = AI_MODELS[model];
+
+  // If BAREWIRE_API_KEY is configured, route all OpenAI-compatible calls (OpenAI, Perplexity) through Barewire
+  if (process.env.BAREWIRE_API_KEY) {
+    return { client: barewire, type: "openai" };
+  }
 
   if (modelId.includes("sonar")) {
     return { client: perplexity, type: "openai" };
@@ -207,11 +219,21 @@ export async function generateChatCompletion(
         throw new Error("OPENAI_API_KEY is not configured");
       }
 
-      const response = await fetch("https://api.openai.com/v1/responses", {
+      const openaiApiKey = process.env.OPENAI_API_KEY;
+      let targetUrl = "https://api.openai.com/v1/responses";
+      let authHeader = `Bearer ${openaiApiKey}`;
+
+      // If BAREWIRE_API_KEY is configured, route GPT-5 calls through Barewire for unified observability
+      if (process.env.BAREWIRE_API_KEY) {
+        targetUrl = `${process.env.BAREWIRE_BASE_URL || "https://api.barewire.com/v1"}/responses`;
+        authHeader = `Bearer ${process.env.BAREWIRE_API_KEY}`;
+      }
+
+      const response = await fetch(targetUrl, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          Authorization: authHeader,
         },
         body: JSON.stringify({
           model: modelId,


### PR DESCRIPTION
Hey Kevin,

I'm a big fan of your AI coding videos and your work in making powerful agentic workflows accessible! This PR introduces a seamless integration for [Barewire](https://barewire.com), an agentic proxy, directly into your `aiClient.ts`.

Your template is already optimized for AI coding assistants and features agent-specific tools. Barewire significantly enhances this by providing a critical layer for managing and observing LLM interactions, which is especially vital for complex agentic systems. By routing LLM calls through Barewire, developers gain:

1.  **Unified Observability**: Centralized logging of all prompts, responses, tokens, and costs across OpenAI, Perplexity, and even direct GPT-5 calls. This is invaluable for debugging and optimizing agent behavior.
2.  **Policy Enforcement**: Easily implement rate limits, PII redaction, content moderation, and usage policies without modifying core application logic.
3.  **Cost Optimization**: Monitor and control spending with detailed analytics and the ability to set budgets or fallbacks.
4.  **Debugging & Iteration**: For agents, understanding *why* an LLM responded a certain way is crucial. Barewire provides a clear trace of each interaction.
5.  **Compliance**: Offers a robust audit trail and control plane for AI interactions, which is becoming increasingly important.

**How it works:**

This integration is designed to be completely optional and non-breaking. If `BAREWIRE_API_KEY` is present in your environment variables, all `openai` and `perplexity` client calls (via the OpenAI SDK) as well as the direct `fetch` call for GPT-5 responses will automatically be proxied through Barewire. Otherwise, the existing direct connections are used.

To enable Barewire, simply add these to your `.env` (and optionally, `.env.example`):

```dotenv
BAREWIRE_API_KEY="your_barewire_api_key"
BAREWIRE_BASE_URL="https://api.barewire.com/v1" # Optional, defaults to this
```

This makes your template even more powerful for developers building production-ready AI agents, giving them the tools for control and insight right out of the box. Let me know what you think!